### PR TITLE
Fix the install documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ echo ":santa^s" | emojify
 
 ```console
 $ git clone https://github.com/b4b4r07/emoji-cli
-$ source ./emoji-cli/emoji-cli.sh
+$ source ./emoji-cli/emoji-cli.zsh
 ```
 
 For [zplug](https://github.com/b4b4r07/zplug) user:


### PR DESCRIPTION
The filename extension of emoji-cli seems to be changed from `sh` to `zsh`.

https://github.com/b4b4r07/emoji-cli/commit/5a1be4c740276ad687d8aae3846d56705b8659cc

Thanks.