### PR TITLE
Return instead of exit when not in interactive shell

### DIFF
--- a/emoji-cli.zsh
+++ b/emoji-cli.zsh
@@ -166,7 +166,7 @@ emoji::cli() {
 # source only
 if [[ ! $- =~ i ]]; then
     echo "this script requires interactive shell mode" 1>&2
-    exit 1
+    return 1
 fi
 
 # zsh only


### PR DESCRIPTION
I'm not sure why you prefer `exit` rather than `return` when a shell is not interactive one, `exit` seems to break some shell integration tools. In my case, one of Atom editor's linter plugin does not work when I install emoji-ci (via zplug) .

So I would like you to replace `exit` with `return` If there's no problem.