### PR TITLE
[fix] Invalid end of regular expressions

### DIFF
--- a/emoji-cli.zsh
+++ b/emoji-cli.zsh
@@ -139,9 +139,9 @@ emoji::cli() {
     _RBUFFER=$RBUFFER
     if [[ -n $LBUFFER ]]; then
         _LBUFFER=${LBUFFER##* }
-        if [[ $_LBUFFER =~ [a-zA-z0-9+_-]$ ]]; then
+        if [[ $_LBUFFER =~ [a-zA-Z0-9+_-]$ ]]; then
             local comp
-            comp="$(echo $_LBUFFER | grep -E -o ":?[a-zA-z0-9+_-]+")"
+            comp="$(echo $_LBUFFER | grep -E -o ":?[a-zA-Z0-9+_-]+")"
             emoji="$(emoji::emoji_get_with_tag "${(L)comp#:}")"
             _BUFFER="${LBUFFER%$comp}${emoji:-$comp}"
         else


### PR DESCRIPTION
Macにおいて
zsh 5.4.2 (x86_64-apple-darwin16.7.0)
においては元のままで全く問題なく動作していましたが

Ubuntu16.04
zsh 5.1.1 (x86_64-ubuntu-linux-gnu)

においてはコマンドライン上に文字列がある状態で起動すると
failed to compile regex invalid range end
と出力されました(クエリ文字列がない状態でfzfは起動しましたが)。
