### PR TITLE
Adding fzy interactive filter

### DIFF
--- a/emoji-cli.zsh
+++ b/emoji-cli.zsh
@@ -10,7 +10,7 @@
 #
 
 EMOJI_CLI_DICT="${0:A:h}/dict/emoji.json"
-: "${EMOJI_CLI_FILTER:="fzf-tmux -d 15%:fzf:peco:percol"}"
+: "${EMOJI_CLI_FILTER:="fzf-tmux -d 15%:fzf:peco:percol:fzy"}"
 : "${EMOJI_CLI_KEYBIND:="^s"}"
 
 # helper functions


### PR DESCRIPTION
Editing `EMOJI_CLI_FILTER` variable in `emoji-cli.zsh` to add support to [fzy](https://github.com/jhawthorn/fzy) text selector.