### PR TITLE
🔧 changed default: EMOJI_CLI_USE_EMOJI=1

### DIFF
--- a/emoji-cli.zsh
+++ b/emoji-cli.zsh
@@ -12,6 +12,7 @@
 EMOJI_CLI_DICT="${0:A:h}/dict/emoji.json"
 : "${EMOJI_CLI_FILTER:="fzf-tmux -d 15%:fzf:peco:percol:fzy"}"
 : "${EMOJI_CLI_KEYBIND:="^s"}"
+EMOJI_CLI_USE_EMOJI=1 # comment out if emoji-code should be returned 
 
 # helper functions
 is_zsh()  { [ -n "$ZSH_VERSION" ];  }


### PR DESCRIPTION
Addresses #23.

Simply set `EMOJI_CLI_USE_EMOJI=1` as the new default value.